### PR TITLE
Add macOS/Linux support with CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Use GCC instead of Clang to avoid compiler crashes (must be set before project())
+set(CMAKE_CXX_COMPILER "/opt/homebrew/bin/g++-15")
+set(CMAKE_C_COMPILER "/opt/homebrew/bin/gcc-15")
+
+project(dx_api_explorer CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Find required packages
+find_package(SDL2 REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+# Include directories
+include_directories(
+    ${SDL2_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/lib/cpp-httplib
+    ${CMAKE_SOURCE_DIR}/lib/imgui
+    ${CMAKE_SOURCE_DIR}/lib/imgui/backends
+    ${CMAKE_SOURCE_DIR}/lib/imgui/misc/cpp
+    ${CMAKE_SOURCE_DIR}/lib/json/single_include
+    ${CMAKE_SOURCE_DIR}/lib
+)
+
+# Source files - Use unity build as designed, GCC handles it better than Clang
+set(SOURCES
+    src/dx_api_build.cpp
+    lib/imgui/imgui.cpp
+    lib/imgui/imgui_demo.cpp
+    lib/imgui/imgui_draw.cpp
+    lib/imgui/imgui_tables.cpp
+    lib/imgui/imgui_widgets.cpp
+    lib/imgui/backends/imgui_impl_sdl2.cpp
+    lib/imgui/backends/imgui_impl_sdlrenderer2.cpp
+    lib/imgui/misc/cpp/imgui_stdlib.cpp
+)
+
+# Create executable
+add_executable(dx_api_explorer ${SOURCES})
+
+# Compiler definitions
+target_compile_definitions(dx_api_explorer PRIVATE
+    CPPHTTPLIB_OPENSSL_SUPPORT
+)
+
+# Remove WIN32_LEAN_AND_MEAN for non-Windows platforms
+if(NOT WIN32)
+    target_compile_definitions(dx_api_explorer PRIVATE
+        # No Windows-specific definitions needed
+    )
+endif()
+
+# Compiler flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(dx_api_explorer PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+        # Disable specific warnings that may not apply on macOS/Linux
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+        # Add -O0 to prevent compiler optimization issues
+        -O0
+        # Increase compiler memory limit
+        -ftemplate-depth=1024
+    )
+endif()
+
+# Link libraries
+target_link_libraries(dx_api_explorer
+    ${SDL2_LIBRARIES}
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+# Copy font file to output directory
+add_custom_command(TARGET dx_api_explorer POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/Cousine-Regular.ttf
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Cousine-Regular.ttf
+)
+
+# Installation rules
+install(TARGETS dx_api_explorer RUNTIME DESTINATION bin)
+install(FILES Cousine-Regular.ttf DESTINATION bin)

--- a/src/dx_api_component_type_procs.cpp
+++ b/src/dx_api_component_type_procs.cpp
@@ -23,7 +23,7 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
 {
     component_t new_component;
     new_component.json = component_json.dump(json_indent);
-    new_component.type = to_component_type(component_json["type"]);
+    new_component.type = to_component_type(component_json["type"].get<std::string>());
 
     switch (new_component.type)
     {
@@ -32,7 +32,7 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
         new_component.class_id = parent_class_id;
         // ...always first.
 
-        new_component.name = component_json["type"];
+        new_component.name = component_json["type"].get<std::string>();
 
         // Always last:
         new_component.debug_string = to_string(new_component.type, new_component.name);
@@ -43,8 +43,8 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
         // ...always first.
 
         auto& config_json = component_json["config"];
-        new_component.name = resolve_name(config_json["name"], app.case_info.content, new_component.class_id);
-        new_component.ref_type = to_component_type(config_json["type"]);
+        new_component.name = resolve_name(config_json["name"].get<std::string>(), app.case_info.content, new_component.class_id);
+        new_component.ref_type = to_component_type(config_json["type"].get<std::string>());
 
         // References might specify a context. If that context exists, we use it if we support it. If it exists
         // and we don't support it, we mark this reference as broken.
@@ -75,7 +75,7 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
         new_component.class_id = parent_class_id;
         // ...always first.
 
-        new_component.name = resolve_name(component_json["name"], app.case_info.content, new_component.class_id);
+        new_component.name = resolve_name(component_json["name"].get<std::string>(), app.case_info.content, new_component.class_id);
 
         // Always last:
         new_component.debug_string = to_string(new_component.type, new_component.name);
@@ -85,11 +85,11 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
         new_component.class_id = component_json["classID"];
         // ...always first.
 
-        new_component.name = resolve_name(component_json["name"], app.case_info.content, new_component.class_id);
+        new_component.name = resolve_name(component_json["name"].get<std::string>(), app.case_info.content, new_component.class_id);
 
         // Views usually, but not always, specify a template in the config.
         auto& config_json = component_json["config"];
-        if (config_json.contains("template")) new_component.ref_type = to_component_type(config_json["template"]);
+        if (config_json.contains("template")) new_component.ref_type = to_component_type(config_json["template"].get<std::string>());
 
         // Always last:
         new_component.debug_string = to_string(new_component.type, new_component.name, new_component.ref_type);
@@ -102,8 +102,8 @@ auto make_component_r(const nlohmann::json& component_json, app_context_t& app, 
         // ...always first.
 
         auto& config_json = component_json["config"];
-        new_component.name = resolve_name(config_json["value"], app.case_info.content, new_component.class_id, false);
-        new_component.label = resolve_label(config_json["label"], app.resources.fields, new_component.class_id);
+        new_component.name = resolve_name(config_json["value"].get<std::string>(), app.case_info.content, new_component.class_id, false);
+        new_component.label = resolve_label(config_json["label"].get<std::string>(), app.resources.fields, new_component.class_id);
 
         // Check for optional attributes.
         if (config_json.contains("disabled")) new_component.is_disabled = to_bool(config_json["disabled"]);

--- a/src/dx_api_draw_procs.h
+++ b/src/dx_api_draw_procs.h
@@ -254,7 +254,7 @@ auto draw_main_window(app_context_t& app) -> void
         ImGui::SetNextWindowSize(ImVec2(main_viewport->WorkSize.x / 2.0f - font_size * 1.5f, main_viewport->WorkSize.y - font_size * 2.0f), ImGuiCond_FirstUseEver);
     }
 
-    if (std::ranges::contains(app.active_events, app_event_type_t::reset_window_layout))
+    if (std::find(app.active_events.begin(), app.active_events.end(), app_event_type_t::reset_window_layout) != app.active_events.end())
     {
         const ImGuiViewport* main_viewport = ImGui::GetMainViewport();
         auto font_size = ImGui::GetFontSize();
@@ -283,9 +283,9 @@ auto draw_main_window(app_context_t& app) -> void
     // different from if we ran on a single thread. But we can at least render
     // a spinner/progress bar/something better than just freezing up.
     // 
-    // Even if we were single threaded, we would still want to work in this manner —
+    // Even if we were single threaded, we would still want to work in this manner ï¿½
     // queue up network operations to take some action and refresh our cache,
-    // then render the updated cache — and its not much harder to do that in multithreaded
+    // then render the updated cache ï¿½ and its not much harder to do that in multithreaded
     // way.
     if (!have_pending_requests)
     {
@@ -394,7 +394,7 @@ auto draw_debug_window(app_context_t& app) -> void
         ImGui::SetNextWindowSize(ImVec2(main_viewport->WorkSize.x - next_pos_x - font_size, main_viewport->WorkSize.y - font_size * 2.0f), ImGuiCond_FirstUseEver);
     }
 
-    if (std::ranges::contains(app.active_events, app_event_type_t::reset_window_layout))
+    if (std::find(app.active_events.begin(), app.active_events.end(), app_event_type_t::reset_window_layout) != app.active_events.end())
     {
         const ImGuiViewport* main_viewport = ImGui::GetMainViewport();
         auto font_size = ImGui::GetFontSize();

--- a/src/dx_api_helper_procs.h
+++ b/src/dx_api_helper_procs.h
@@ -43,13 +43,13 @@ auto to_lower(std::string_view str) -> std::string
 //
 // You shouldn't have to specifiy the enum count because that should be inferred
 // from the enum strings parameter.
-template<typename enum_t, int enum_count>
+template<typename enum_t, size_t enum_count>
 auto to_enum(std::string_view str, enum_c_strs_t<enum_count> enum_strings) -> enum_t
 {
     auto str_lower = to_lower(str);
     auto result = static_cast<enum_t>(1);
     auto count = enum_count;
-    for (int i = result + 1; i < count; ++i)
+    for (size_t i = result + 1; i < count; ++i)
     {
         auto enum_str = enum_strings[i];
         auto enum_str_lower = to_lower(enum_str);

--- a/src/dx_api_helper_types.h
+++ b/src/dx_api_helper_types.h
@@ -33,7 +33,7 @@ public:
 };
 
 // For enum type specifier strings.
-template<int enum_count>
+template<size_t enum_count>
 using enum_c_strs_t = std::array<const char*, enum_count>;
 }
 

--- a/src/dx_api_model_types.h
+++ b/src/dx_api_model_types.h
@@ -55,7 +55,7 @@ enum component_type_t
 };
 
 // Component strings as we'll see them in DX API responses, should be in same order as enum.
-constexpr enum_c_strs_t component_type_strings =
+constexpr std::array<const char*, component_type_count> component_type_strings =
 {
     "Unspecified",
     "Unknown",

--- a/src/dx_api_network_types.h
+++ b/src/dx_api_network_types.h
@@ -30,7 +30,7 @@ enum http_method_t
 };
 
 // Strings that correspond to http method enums.
-constexpr enum_c_strs_t http_method_strings =
+constexpr std::array<const char*, http_method_count> http_method_strings =
 {
     "Unspecified",
     "Unknown",


### PR DESCRIPTION
- Add CMakeLists.txt for cross-platform builds
- Fix C++20 compatibility issues with modern GCC/Clang
- Replace C++23 std::ranges::contains with C++20 std::find
- Fix template parameter types (int -> size_t)
- Add explicit JSON to string conversions
- Specify array sizes explicitly for template deduction
- Tested on macOS Apple Silicon with GCC 15.2.0